### PR TITLE
Fix scala issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 intellij {
     version = 'IC-2021.1' // IC Community Edition
     updateSinceUntilBuild false //Disables updating since-build attribute in plugin.xml
-    plugins = ['com.intellij.java', 'org.intellij.scala:2021.1.16' , 'PsiViewer:211.6305.21-EAP-SNAPSHOT'] // load the the scala-plugin
+    plugins = ['com.intellij.java', 'org.intellij.scala:2021.1.21' , 'PsiViewer:211-SNAPSHOT'] // load the the scala-plugin
     pluginName = 'bytecode-disassembler'
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/org/opalj/intellijintegration/Actions/openclass/PsiClassAction.java
+++ b/src/main/java/org/opalj/intellijintegration/Actions/openclass/PsiClassAction.java
@@ -58,14 +58,26 @@ public class PsiClassAction extends AnAction {
         if (classes.length == 1) return classes[0];
 
         TextRange textRange = psiElement.getTextRange();
+        PsiClass largestClass = classes[0];
+        int largestSize = 0;
         if (textRange != null) {
           for (PsiClass aClass : classes) {
             PsiElement navigationElement = aClass.getNavigationElement();
             TextRange classRange =
                 navigationElement != null ? navigationElement.getTextRange() : null;
-            if (classRange != null && classRange.contains(textRange)) return aClass;
+            if (classRange != null) {
+              if (classRange.contains(textRange)) return aClass;
+              int size = classRange.getEndOffset() - classRange.getStartOffset();
+              if (size > largestSize) {
+                largestClass = aClass;
+                largestSize = size;
+              }
+            }
           }
         }
+
+        // If there are multiple classes in a file, return the largest class of the file
+        return largestClass;
       }
       return null;
     }


### PR DESCRIPTION
Fixes two issues common for scala files:
- Scala source files may contain more than one class. Instead of failing, try to open the largest one, which is most likely what the user expects.
- Prevent rewriting of invokedynamic and dynamic constants. These can create additional classfiles that might be opened instead of the one we wanted.